### PR TITLE
Updates the news fetching logic to paginate using article UUIDs instead of integer IDs

### DIFF
--- a/database/crud.py
+++ b/database/crud.py
@@ -12,7 +12,7 @@ from schemas.news import NewsResponse
 from utils.utils import article_to_news_response
 
 
-def get_news_from_db(db: Session, last_item_id: int, limit: int = 100) -> list[NewsResponse]:
+def get_news_from_db(db: Session, last_item_id: int = 0, limit: int = 100) -> list[NewsResponse]:
     articles = (
         db.query(Article)
         .options(joinedload(Article.source))
@@ -36,6 +36,10 @@ def get_trending_news_from_db(
     )
     articles = cast(List[Article], articles)
     return [article_to_news_response(article) for article in articles]
+
+
+def get_article_by_uuid(db: Session, uuid: str) -> Article | None:
+    return db.query(Article).filter(Article.uuid == uuid).first()
 
 
 def save_articles(articles: list[dict]):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import FastAPI
@@ -29,12 +29,24 @@ def shutdown_event():
 
 
 @app.get("/fetch_news", response_model=List[NewsResponse])
-def fetch_news(last_item_id: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def fetch_news(
+        last_item_uuid: Optional[str] = None,
+        limit: int = 100, db: Session = Depends(get_db)
+):
     if limit > 100: limit = 100
+    article = crud.get_article_by_uuid(db=db, uuid=last_item_uuid)
+    # If UUID not found (e.g., scraper DB reset), start from the first article
+    last_item_id = article.id if article else 0
     return crud.get_news_from_db(db=db, last_item_id=last_item_id, limit=limit)
 
 
 @app.get("/fetch_trending_news", response_model=List[NewsResponse])
-def fetch_trending_news(last_item_id: int = 0, limit: int = 50, db: Session = Depends(get_db)):
+def fetch_trending_news(
+        last_item_uuid: Optional[str] = None,
+        limit: int = 50,
+        db: Session = Depends(get_db)
+):
     if limit > 50: limit = 50
+    article = crud.get_article_by_uuid(db=db, uuid=last_item_uuid)
+    last_item_id = article.id if article else 0
     return crud.get_trending_news_from_db(db=db, last_item_id=last_item_id, limit=limit)

--- a/models/news.py
+++ b/models/news.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean
 from sqlalchemy.orm import relationship
 
@@ -16,6 +18,7 @@ class Article(Base):
     __tablename__ = "articles"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    uuid = Column(String, default=lambda: str(uuid.uuid4()), unique=True, index=True)
     title = Column(String, nullable=False)
     url = Column(String, nullable=False)
     urlToImage = Column(String)

--- a/schemas/news.py
+++ b/schemas/news.py
@@ -14,6 +14,7 @@ class SourceResponse(BaseModel):
 
 class NewsResponse(BaseModel):
     id: int
+    uuid: str
     title: str
     url: str
     urlToImage: Optional[str]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -21,6 +21,7 @@ def article_to_news_response(article: Article):
     )
     news_response = NewsResponse(
         id=article.id,
+        uuid=article.uuid,
         title=article.title,
         url=article.url,
         description=article.description,


### PR DESCRIPTION
## Changes
- Updated `fetch_news` endpoint to use UUIDs for pagination.
- If the `last_item_uuid` is not found, default to starting from the oldest available article (ID = 0).
- Prevents pagination failures when scraper's temporary in-memory DB is reset.
- Ensures robust, controlled client behavior with minimal assumptions about the scraper DB state.

## Why
Previously, pagination depended on auto-incremented IDs from the scraper DB. Since the scraper uses an in-memory SQLite DB that can reset, relying on sequential IDs was fragile.  
Using UUIDs guarantees global uniqueness across resets and avoids breaking pagination after a scraper reset.

## Notes
- Client is trusted (internal backend), so no need for strict validation when UUID is missing.
- Pagination remains efficient, and fallback behavior is intentional and acceptable for the application's design.